### PR TITLE
fix: update -absf ffmpeg argument to -bsf:a

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
   "typescript.tsdk": "./node_modules/typescript/lib",
   "css.validate": false,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,

--- a/src/lib/m3u8-convert.ts
+++ b/src/lib/m3u8-convert.ts
@@ -22,7 +22,7 @@ export async function m3u8Convert(options: M3u8DLOptions, data: TsItemInfo[]) {
     if (process.platform === 'win32') filesAllArr = filesAllArr.map(d => d.replaceAll('\\', '/'));
     await promises.writeFile(inputFilePath, 'ffconcat version 1.0\nfile ' + filesAllArr.join('\nfile '));
 
-    const cmd = `ffmpeg -y -f concat -safe 0 -i ${inputFilePath} -acodec copy -vcodec copy -absf aac_adtstoasc "${filepath}"`;
+    const cmd = `ffmpeg -y -f concat -safe 0 -i ${inputFilePath} -acodec copy -vcodec copy -bsf:a aac_adtstoasc "${filepath}"`;
     logger.debug('[convert to mp4]cmd:', cyan(cmd));
     const r = execSync(cmd);
     ffmpegSupport = !r.error;


### PR DESCRIPTION
FFmpeg has made changes to the -vbsf/-absf/-sbsf options, and has been replaced with -bsf, which is causing converting from .ts to .mp4 fail.

# * -vbsf/-absf/-sbsf options were removed and replaced by a -bsf option which
      uses stream specifiers. Use -bsf:v/a/s instead of the old options.

[FFmpeg Changelog](https://github.com/FFmpeg/FFmpeg/blob/master/Changelog)