### PR TITLE
fix(server): keep the Web UI responsive during ffmpeg merge/convert

### DIFF
--- a/packages/frontend/src/components/CompletedList.vue
+++ b/packages/frontend/src/components/CompletedList.vue
@@ -309,12 +309,10 @@ const currentPage = ref(1);
 const pageSize = ref(20);
 const goToPageInput = ref('');
 
-// 获取已完成的任务（progress === 100 或 status === 'done'）
+// 获取已完成的任务
 const completedTasks = computed(() => {
   const allTasks = Object.values(tasksStore.tasks);
-  const completed = allTasks.filter(
-    task => (task.status === 'done' || (task.progress !== undefined && task.progress >= 100))
-  );
+  const completed = allTasks.filter(task => task.status === 'done');
   // 设置 showName，与 tasks store 中的逻辑保持一致
   completed.forEach(task => {
     task.showName = task.filename || task.dlOptions?.filename || task.localVideo || task.url;

--- a/packages/frontend/src/stores/tasks.ts
+++ b/packages/frontend/src/stores/tasks.ts
@@ -19,7 +19,7 @@ export const useTasksStore = defineStore('tasks', () => {
 
     // 过滤掉已完成的任务（已完成的任务只在已完成页面显示）
     taskList = taskList.filter(task => {
-      const isCompleted = task.status === 'done' || (task.progress !== undefined && task.progress >= 100);
+      const isCompleted = task.status === 'done';
       return !isCompleted;
     });
 

--- a/src/lib/m3u8-convert.ts
+++ b/src/lib/m3u8-convert.ts
@@ -1,9 +1,76 @@
-import { createWriteStream, existsSync, readFileSync, statSync, unlinkSync, writeFileSync } from 'node:fs';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { createReadStream, createWriteStream, existsSync, statSync, unlinkSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
-import { execSync, formatByteSize, mkdirp } from '@lzwme/fe-utils';
+import { formatByteSize, mkdirp } from '@lzwme/fe-utils';
 import { cyan, greenBright, magentaBright } from 'console-log-colors';
 import type { M3u8DLOptions, TsItemInfo } from '../types/m3u8';
 import { isSupportFfmpeg, logger } from './utils';
+
+function formatCommand(ffmpegBin: string, args: string[]) {
+  return [ffmpegBin, ...args].map(arg => (/[\s"]/u.test(arg) ? `"${arg.replaceAll('"', '\\"')}"` : arg)).join(' ');
+}
+
+async function runFfmpeg(ffmpegBin: string, args: string[]) {
+  return await new Promise<{ error?: Error; stderr: string }>(resolve => {
+    const child = spawn(ffmpegBin, args, {
+      stdio: ['ignore', 'ignore', 'pipe'],
+      windowsHide: true,
+    });
+    let stderr = '';
+    let settled = false;
+    const finish = (result: { error?: Error; stderr: string }) => {
+      if (settled) return;
+      settled = true;
+      resolve(result);
+    };
+
+    child.stderr?.setEncoding('utf8');
+    child.stderr?.on('data', (chunk: string) => {
+      stderr = `${stderr}${chunk}`.slice(-8_000);
+    });
+    child.once('error', error => finish({ error, stderr }));
+    child.once('close', code => {
+      if (code === 0) finish({ stderr });
+      else finish({ error: new Error(`ffmpeg exited with code ${code}`), stderr });
+    });
+  });
+}
+
+async function appendTsFiles(filepath: string, data: TsItemInfo[]) {
+  const filteWriteStream = createWriteStream(filepath);
+
+  for (const d of data) {
+    if (!existsSync(d.tsOut)) continue;
+
+    const error = await new Promise<Error | null>(resolve => {
+      const readStream = createReadStream(d.tsOut);
+      const onError = (err: Error) => {
+        cleanup();
+        resolve(err);
+      };
+      const onEnd = () => {
+        cleanup();
+        resolve(null);
+      };
+      const cleanup = () => {
+        readStream.off('error', onError);
+        filteWriteStream.off('error', onError);
+        readStream.off('end', onEnd);
+      };
+
+      readStream.once('error', onError);
+      filteWriteStream.once('error', onError);
+      readStream.once('end', onEnd);
+      readStream.pipe(filteWriteStream, { end: false });
+    });
+
+    if (error) logger.error(`Write file failed: ${d.tsOut}`, error);
+  }
+
+  filteWriteStream.end();
+  await once(filteWriteStream, 'finish');
+}
 
 export async function m3u8Convert(options: M3u8DLOptions, data: TsItemInfo[]) {
   const ffmpegBin = options.ffmpegPath || 'ffmpeg';
@@ -24,24 +91,49 @@ export async function m3u8Convert(options: M3u8DLOptions, data: TsItemInfo[]) {
     if (process.platform === 'win32') filesAllArr = filesAllArr.map(d => d.replaceAll('\\', '/'));
     writeFileSync(ffconcatFile, `ffconcat version 1.0\n${filesAllArr.join('\n')}`);
 
-    // ffmpeg -i nz.ts -c copy -map 0:v -map 0:a -bsf:a aac_adtstoasc nz.mp4
-    // const cmd = `"${ffmpegBin}" -async 1 -y -f concat -safe 0 -i "${ffconcatFile}" -acodec copy -vcodec copy -bsf:a aac_adtstoasc "${filepath}"`;
-    const cmd = `"${ffmpegBin}" -async 1 -y -f concat -safe 0 -i "${ffconcatFile}" -c:v copy -c:a copy -movflags +faststart -fflags +genpts -bsf:a aac_adtstoasc "${filepath}"`;
-    logger.debug('[convert to mp4]cmd:', cyan(cmd));
-    const r = execSync(cmd);
-    ffmpegSupport = !r.error;
-    if (r.error) logger.error(`Conversion to mp4 failed. Please confirm that \`${ffmpegBin}\` is installed and available!`, r.stderr);
-    else unlinkSync(ffconcatFile);
+    const args = [
+      '-hide_banner',
+      '-loglevel',
+      'error',
+      '-nostats',
+      '-async',
+      '1',
+      '-y',
+      '-f',
+      'concat',
+      '-safe',
+      '0',
+      '-i',
+      ffconcatFile,
+      '-c:v',
+      'copy',
+      '-c:a',
+      'copy',
+      '-movflags',
+      '+faststart',
+      '-fflags',
+      '+genpts',
+      '-bsf:a',
+      'aac_adtstoasc',
+      filepath,
+    ];
+    logger.debug('[convert to mp4]cmd:', cyan(formatCommand(ffmpegBin, args)));
+
+    try {
+      const r = await runFfmpeg(ffmpegBin, args);
+      ffmpegSupport = !r.error;
+      if (r.error) {
+        if (existsSync(filepath)) unlinkSync(filepath);
+        logger.error(`Conversion to mp4 failed with \`${ffmpegBin}\`.`, r.stderr || r.error.message);
+      }
+    } finally {
+      if (existsSync(ffconcatFile)) unlinkSync(ffconcatFile);
+    }
   }
 
   if (!ffmpegSupport) {
     filepath = filepath.replace(/\.mp4$/, '.ts');
-    const filteWriteStream = createWriteStream(filepath);
-    for (const d of data) {
-      const err = await new Promise(rs => filteWriteStream.write(readFileSync(d.tsOut), e => rs(e)));
-      if (err) logger.error(`Write file failed: ${d.tsOut}`, err);
-    }
-    filteWriteStream.end();
+    await appendTsFiles(filepath, data);
   }
 
   if (!existsSync(filepath)) return '';

--- a/src/lib/m3u8-download.ts
+++ b/src/lib/m3u8-download.ts
@@ -304,7 +304,8 @@ export async function m3u8Download(url: string, options: M3u8DLOptions = {}) {
           // 如果当前速度小于平均速度，则更新为平均速度
           if (stats.speed < stats.avgSpeed) stats.speed = stats.avgSpeed;
           stats.speedDesc = `${formatByteSize(stats.speed)}/s`;
-          stats.progress = Math.floor((finished / m3u8Info.tsCount) * 100);
+          stats.progress =
+            finished === m3u8Info.tsCount && options.convert !== false ? 99 : Math.floor((finished / m3u8Info.tsCount) * 100);
 
           if (downloadedDuration) {
             stats.remainingTime = (timeCost / downloadedDuration) * (m3u8Info.duration - stats.durationDownloaded);
@@ -361,11 +362,13 @@ export async function m3u8Download(url: string, options: M3u8DLOptions = {}) {
       logger.warn(t('download.status.downloadFailedRetry', lang), stats.tsFailed);
     } else if (options.convert !== false) {
       stats.errmsg = t('download.status.mergingVideo', lang);
+      stats.remainingTime = 0;
       if (options.onProgress) options.onProgress(stats.tsCount, m3u8Info.tsCount, null, stats);
       result.filepath = await m3u8Convert(options, m3u8Info.data);
       stats.errmsg = result.filepath ? '' : t('download.status.mergeFailed', lang);
 
       if (result.filepath && existsSync(result.filepath)) {
+        stats.progress = 100;
         stats.size = statSync(result.filepath).size;
         if (options.delCache) rmrfAsync(dirname(m3u8Info.data[0].tsOut));
       }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix.

* **What is the current behavior?** (You can also link to an open issue here)

When a download reaches the ffmpeg merge/convert stage, the server runs ffmpeg via a synchronous child-process call. That blocks the Node.js event loop until ffmpeg exits, so the Web UI becomes unresponsive: HTTP requests stall, WebSocket updates stop, and in Docker deployments the freeze is especially noticeable because ffmpeg and overlayfs IO usually take longer.

There is also a related UI state issue: tasks with `progress >= 100` are moved into the completed list before the final file is actually written, which makes the merge stage look finished even though the task is still running.

* **What is the new behavior (if this is a feature change)?**

- Run ffmpeg asynchronously with `spawn(...)` so the server can continue handling HTTP and WebSocket traffic while the merge is in progress.
- Keep merge tasks at 99% until the final file is successfully created, then move them to 100%.
- Only treat `status === 'done'` as completed in the frontend, so active merge tasks stay in the active list until the final output is ready.
- Keep the non-ffmpeg TS merge fallback non-blocking as well by streaming segment files instead of reading them synchronously into memory.

* **Other information**:

Verified locally with:
- `pnpm test`
- `pnpm build:cjs`
- `pnpm -F @lzwme/m3u8-dl-frontend build`

This change is intentionally small and keeps the existing download flow intact; it only removes the event-loop blocking behavior during the final merge stage and makes the UI state line up with the real task lifecycle.
